### PR TITLE
Fix bug with regex functions

### DIFF
--- a/oxy.php
+++ b/oxy.php
@@ -1,4 +1,7 @@
 <?php
+mb_internal_encoding("UTF-8");
+mb_regex_encoding('UTF-8');
+
 require('oxy_dictionary.php');
 if (false) { class oxy extends _oxy {} }
 abstract class _oxy extends _oxy_dictionary {


### PR DESCRIPTION
The `Str::replace` function is buggy when using euro sign because of the lack of explicit encoding set.

PHP `mb_split` thinks the encoding is Japanese.

eg:

```
//mb_regex_encoding('UTF-8'); // Uncomment to display correct result
echo "<pre>";
var_dump( mb_split( "a" , "a132€a" ) );
var_dump( mb_regex_encoding() );
die();
```
